### PR TITLE
Expose shipping and billing context across order dashboards

### DIFF
--- a/app/Http/Controllers/Admin/PedidoController.php
+++ b/app/Http/Controllers/Admin/PedidoController.php
@@ -11,16 +11,20 @@ class PedidoController extends Controller
 {
     public function index()
     {
-        $pedidos = Pedido::with(['cliente', 'repartidor', 'productos'])->latest()->get();
+        $pedidos = Pedido::with([
+            'cliente:id,name,email,telefono',
+            'repartidor:id,name,telefono',
+            'itemsSupermercado.producto:id,nombre,precio,vendor_id',
+        ])->latest()->get();
 
         // CORREGIDO: Usar 'role' en lugar de 'rol'
         $repartidores = User::where('role', 'repartidor')->where('estado', 'activo')->get();
 
         $totalPedidos = $pedidos->count();
-        $pendientesCount = $pedidos->where('estado', 'pendiente')->count();
-        $preparandoCount = $pedidos->where('estado', 'preparando')->count();
-        $listosCount = $pedidos->where('estado', 'listo')->count();
-        $entregadosCount = $pedidos->where('estado', 'entregado')->count();
+        $pendientesCount = $pedidos->where('estado_global', 'pendiente')->count();
+        $preparandoCount = $pedidos->where('estado_global', 'preparando')->count();
+        $listosCount = $pedidos->where('estado_global', 'listo')->count();
+        $entregadosCount = $pedidos->where('estado_global', 'entregado')->count();
 
         return view('admin.pedidos.index', compact(
             'pedidos',
@@ -35,7 +39,12 @@ class PedidoController extends Controller
 
     public function show($id)
     {
-        $pedido = Pedido::with(['cliente', 'repartidor', 'productos'])->findOrFail($id);
+        $pedido = Pedido::with([
+            'cliente:id,name,email,telefono',
+            'repartidor:id,name,telefono',
+            'itemsSupermercado.producto:id,nombre,precio,vendor_id',
+        ])->findOrFail($id);
+
         return response()->json($pedido);
     }
 
@@ -47,7 +56,7 @@ class PedidoController extends Controller
 
         $pedido = Pedido::findOrFail($id);
         $pedido->repartidor_id = $request->repartidor_id;
-        $pedido->estado = 'preparando';
+        $pedido->estado_global = 'preparando';
         $pedido->save();
 
         return redirect()->route('admin.pedidos.index')->with('success', 'Repartidor asignado correctamente.');
@@ -60,7 +69,7 @@ class PedidoController extends Controller
         ]);
 
         $pedido = Pedido::findOrFail($id);
-        $pedido->estado = $request->estado;
+        $pedido->estado_global = $request->estado;
         $pedido->save();
 
         return redirect()->route('admin.pedidos.index')->with('success', 'Estado del pedido actualizado correctamente.');
@@ -74,7 +83,7 @@ class PedidoController extends Controller
 
         $pedido = Pedido::findOrFail($pedido);
         $pedido->repartidor_id = $request->repartidor_id;
-        $pedido->estado = 'preparando';
+        $pedido->estado_global = 'preparando';
         $pedido->save();
 
         return redirect()->route('admin.pedidos.index')->with('success', 'Repartidor asignado correctamente.');

--- a/app/Http/Controllers/CarritoController.php
+++ b/app/Http/Controllers/CarritoController.php
@@ -121,21 +121,27 @@ class CarritoController extends Controller
         $total     = $subtotal - $descuento + $envio;
 
         $direccionEnvio = [
-            'descripcion'     => $data['direccion'],
-            'telefono'        => $data['telefono'],
-            'referencia'      => $data['referencia'] ?? null,
-            'colonia'         => $data['colonia'],
-            'lat'             => $data['lat'] ?? null,
-            'lng'             => $data['lng'] ?? null,
-            'factura'         => $data['factura'] === 'si',
-            'nit'             => $data['factura'] === 'si' ? ($data['nit'] ?? null) : null,
-            'razon_social'    => $data['factura'] === 'si' ? ($data['razon_social'] ?? null) : null,
-            'nombre_empresa'  => $data['factura'] === 'si' ? ($data['nombre_empresa'] ?? null) : null,
+            'descripcion' => $data['direccion'],
+            'telefono'    => $data['telefono'],
+            'referencia'  => $data['referencia'] ?? null,
+            'colonia'     => $data['colonia'],
+            'lat'         => $data['lat'] ?? null,
+            'lng'         => $data['lng'] ?? null,
+        ];
+
+        $facturacion = [
+            'requiere'  => $data['factura'] === 'si',
+            'nit'       => $data['factura'] === 'si' ? ($data['nit'] ?? 'CF') : 'CF',
+            'nombre'    => $data['factura'] === 'si'
+                ? ($data['razon_social'] ?? $data['nombre_empresa'] ?? null)
+                : null,
+            'direccion' => $data['factura'] === 'si' ? $data['direccion'] : null,
+            'telefono'  => $data['telefono'],
         ];
 
         $pedido = null;
 
-        DB::transaction(function () use ($data, $subtotal, $descuento, $envio, $total, $direccionEnvio, $carrito, &$pedido) {
+        DB::transaction(function () use ($data, $subtotal, $descuento, $envio, $total, $direccionEnvio, $facturacion, $carrito, &$pedido) {
             $pedido = Pedido::create([
                 'user_id'         => Auth::id(),
                 'repartidor_id'   => null,
@@ -147,6 +153,7 @@ class CarritoController extends Controller
                 'estado_pago'     => 'pendiente',
                 'estado_global'   => 'pendiente',
                 'direccion_envio' => $direccionEnvio,
+                'facturacion'     => $facturacion,
             ]);
 
             $productosDB = Producto::whereIn('id', array_keys($carrito))->get()->keyBy('id');

--- a/app/Http/Controllers/Vendedor/PedidoController.php
+++ b/app/Http/Controllers/Vendedor/PedidoController.php
@@ -33,26 +33,34 @@ class PedidoController extends Controller
         ]);
 
         // Normaliza posibles JSON guardados como string
-        $dir = $pedido->direccion_envio;
-        if (is_string($dir)) $dir = json_decode($dir, true) ?: null;
-
-        $fac = $pedido->facturacion;
-        if (is_string($fac)) $fac = json_decode($fac, true) ?: [];
+        $dir = $pedido->direccion_envio ?? [];
 
         $telefonoCliente = data_get($dir, 'telefono') ?: data_get($pedido->cliente, 'telefono');
 
         $facturacion = [
-            'requiere'  => (bool) data_get($fac, 'requiere', false),
-            'nit'       => data_get($fac, 'nit', 'CF'),
-            'nombre'    => data_get($fac, 'nombre'),
-            'direccion' => data_get($fac, 'direccion'),
+            'requiere'  => (bool) data_get($pedido->facturacion, 'requiere', false),
+            'nit'       => data_get($pedido->facturacion, 'nit', 'CF'),
+            'nombre'    => data_get($pedido->facturacion, 'nombre'),
+            'direccion' => data_get($pedido->facturacion, 'direccion'),
+            'telefono'  => data_get($pedido->facturacion, 'telefono'),
         ];
+
+        $lat = data_get($dir, 'lat');
+        $lng = data_get($dir, 'lng');
+        $dirTexto = $pedido->direccion_formateada;
+        $googleMapsUrl = ($lat && $lng)
+            ? sprintf('https://www.google.com/maps?q=%s,%s', $lat, $lng)
+            : null;
 
         return view('Vendedor.pedidos.show', [
             'pedido'          => $pedido,
             'pedidoItems'     => $pedido->items, // ya filtrados por vendor
             'telefonoCliente' => $telefonoCliente,
             'facturacion'     => $facturacion,
+            'direccion'       => $dir,
+            'direccionTexto'  => $dirTexto,
+            'coordenadas'     => ['lat' => $lat, 'lng' => $lng, 'google' => $googleMapsUrl],
+            'metodoPago'      => $pedido->metodo_pago,
         ]);
     }
 

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Payment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'pedido_id',
+        'provider',
+        'external_id',
+        'monto',
+        'status',
+        'payload',
+    ];
+
+    protected $casts = [
+        'monto'   => 'decimal:2',
+        'payload' => 'array',
+    ];
+
+    public function pedido(): BelongsTo
+    {
+        return $this->belongsTo(Pedido::class);
+    }
+}

--- a/database/migrations/2025_09_09_071900_add_facturacion_to_pedidos_table.php
+++ b/database/migrations/2025_09_09_071900_add_facturacion_to_pedidos_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            if (!Schema::hasColumn('pedidos', 'facturacion')) {
+                $table->json('facturacion')->nullable()->after('direccion_envio');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pedidos', function (Blueprint $table) {
+            if (Schema::hasColumn('pedidos', 'facturacion')) {
+                $table->dropColumn('facturacion');
+            }
+        });
+    }
+};

--- a/resources/views/Vendedor/pdf/comprobante.blade.php
+++ b/resources/views/Vendedor/pdf/comprobante.blade.php
@@ -44,12 +44,17 @@
         <div class="box">
             <h3>Entrega</h3>
             @php
-                $dir = $pedido->direccion_envio;
-                if (is_string($dir)) $dir = json_decode($dir, true) ?: null;
-                if (is_object($dir)) $dir = (array) $dir;
+                $dir = $pedido->direccion_envio ?? [];
+                $texto = [];
+                if (!empty($dir['descripcion'])) $texto[] = $dir['descripcion'];
+                if (!empty($dir['colonia'])) $texto[] = $dir['colonia'];
+                $dirTexto = $texto ? implode(', ', $texto) : '--';
             @endphp
-            <div>{{ $dir['direccion'] ?? ($dir ?? '--') }}</div>
+            <div>{{ $dirTexto }}</div>
             @if(!empty($dir['referencia']))<div>Ref: {{ $dir['referencia'] }}</div>@endif
+            @if(!empty($dir['lat']) && !empty($dir['lng']))
+                <div>Coordenadas: {{ $dir['lat'] }}, {{ $dir['lng'] }}</div>
+            @endif
         </div>
     </div>
 
@@ -82,7 +87,20 @@
         <tr><td class="right">Subtotal:</td><td class="right">Q {{ number_format($subtotal,2) }}</td></tr>
         <tr><td class="right">IVA (12%):</td><td class="right">Q {{ number_format($iva,2) }}</td></tr>
         <tr><td class="right"><strong>Total pagado:</strong></td><td class="right"><strong>Q {{ number_format($total,2) }}</strong></td></tr>
+        <tr><td class="right">Método de pago:</td><td class="right">{{ ucfirst(str_replace('_',' ', $pedido->metodo_pago ?? 'efectivo')) }}</td></tr>
     </table>
+
+    @php
+        $fac = $pedido->facturacion ?? [];
+    @endphp
+    @if(!empty($fac['requiere']))
+        <div class="box" style="margin-top:10px;">
+            <h3>Datos de facturación</h3>
+            <div>NIT: {{ $fac['nit'] ?? 'CF' }}</div>
+            <div>Nombre: {{ $fac['nombre'] ?? 'Consumidor Final' }}</div>
+            <div>Dirección: {{ $fac['direccion'] ?? '—' }}</div>
+        </div>
+    @endif
 
     <div class="thanks">¡Gracias por su compra!</div>
 </div>

--- a/resources/views/Vendedor/pedidos/show.blade.php
+++ b/resources/views/Vendedor/pedidos/show.blade.php
@@ -7,6 +7,8 @@
     <title>Detalles del Pedido - Vendedor</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7kGStbFh8g1FVLzeuL1Yypw5v1sC0qf2m0wEgg=" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kGStbFh8g1FVLzeuL1Yypw5v1sC0qf2m0wEgg=" crossorigin=""></script>
 
     <style>
         /* Paleta fija (sin variables CSS) */
@@ -47,6 +49,7 @@
         .repartidor-section{background:#F9F2F3;padding:16px;border-radius:10px;margin-top:16px}
         .repartidor-select{display:flex;gap:10px;align-items:center;margin-top:10px;flex-wrap:wrap}
         .tools{display:flex;gap:8px;flex-wrap:wrap}
+        #mapa-envio{width:100%;height:260px;border-radius:12px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,.08);margin-top:16px;border:1px solid #D9A6A6}
         @media (max-width:768px){
             .header{flex-direction:column;align-items:flex-start;gap:12px}
             .info-list li{flex-direction:column}
@@ -86,23 +89,11 @@
     elseif (is_object($dirRaw))  $dirArr = (array) $dirRaw;
     elseif (is_array($dirRaw))   $dirArr = $dirRaw;
 
-    $dirTexto = $dirArr
-        ? trim(($dirArr['direccion'] ?? '') . (isset($dirArr['referencia']) ? ' (Ref: '.$dirArr['referencia'].')' : ''))
-        : (is_string($dirRaw) ? $dirRaw : null);
-
-    // Teléfono con fallbacks
-    $telefono = data_get($dirArr, 'telefono') ?? ($cliente->telefono ?? null);
-
-    // Facturación (puede ser JSON string / array / obj)
-    $facRaw = $pedido->facturacion ?? null;
-    if (is_string($facRaw)) $facRaw = json_decode($facRaw, true) ?: [];
-    if (is_object($facRaw)) $facRaw = (array) $facRaw;
-    $facturacion = [
-        'requiere'  => (bool) data_get($facRaw, 'requiere', false),
-        'nit'       => data_get($facRaw, 'nit', 'CF'),
-        'nombre'    => data_get($facRaw, 'nombre'),
-        'direccion' => data_get($facRaw, 'direccion'),
-    ];
+    $dirArr = $direccion ?? $dirArr;
+    $dirTexto = $direccionTexto ?? ($dirTexto ?? null);
+    $telefono = $telefonoCliente ?? ($cliente->telefono ?? null);
+    $coords   = $coordenadas ?? ['lat'=>null,'lng'=>null,'google'=>null];
+    $metodo   = $metodoPago ?? ($pedido->metodo_pago ?? null);
 @endphp
 
 <div class="container">
@@ -158,6 +149,21 @@
                     <span>{{ $dirTexto ?? '—' }}</span>
                 </li>
                 <li>
+                    <strong><i class="fas fa-money-check-alt"></i> Método de pago:</strong>
+                    <span class="text-capitalize">{{ $metodo ? str_replace('_',' ', $metodo) : '—' }}</span>
+                </li>
+                @if($coords['lat'] && $coords['lng'])
+                    <li>
+                        <strong><i class="fas fa-location-arrow"></i> Coordenadas:</strong>
+                        <span>
+                            {{ $coords['lat'] }}, {{ $coords['lng'] }}
+                            @if($coords['google'])
+                                · <a href="{{ $coords['google'] }}" target="_blank" class="text-decoration-none">Abrir en Google Maps</a>
+                            @endif
+                        </span>
+                    </li>
+                @endif
+                <li>
                     <strong><i class="fas fa-phone"></i> Teléfono:</strong>
                     <span>{{ $telefono ?? '—' }}</span>
                 </li>
@@ -174,7 +180,19 @@
                         <li><strong><i class="fas fa-id-card"></i> NIT:</strong> <span>{{ $facturacion['nit'] ?? 'CF' }}</span></li>
                         <li><strong><i class="fas fa-user"></i> Nombre:</strong> <span>{{ $facturacion['nombre'] ?? '—' }}</span></li>
                         <li><strong><i class="fas fa-home"></i> Dirección fiscal:</strong> <span>{{ $facturacion['direccion'] ?? '—' }}</span></li>
+                        @if(!empty($facturacion['telefono']))
+                            <li><strong><i class="fas fa-phone"></i> Teléfono:</strong> <span>{{ $facturacion['telefono'] }}</span></li>
+                        @endif
                     </ul>
+                </div>
+            @endif
+
+            @if(!empty($coords['lat']) && !empty($coords['lng']))
+                <div class="card mt-3">
+                    <div class="card-header">
+                        <h3><i class="fas fa-map"></i> Ubicación en mapa</h3>
+                    </div>
+                    <div id="mapa-envio"></div>
                 </div>
             @endif
 
@@ -291,6 +309,19 @@
         if (!select.value) { alert('Por favor selecciona un repartidor'); return; }
         alert('Repartidor asignado (demo). Implementa el POST real aquí.');
     }
+
+    // Mapa
+    @if(!empty($coords['lat']) && !empty($coords['lng']))
+    document.addEventListener('DOMContentLoaded', () => {
+        const map = L.map('mapa-envio').setView([{{ $coords['lat'] }}, {{ $coords['lng'] }}], 16);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; OpenStreetMap'
+        }).addTo(map);
+        L.marker([{{ $coords['lat'] }}, {{ $coords['lng'] }}]).addTo(map)
+            .bindPopup(@json($dirTexto ?? 'Ubicación de entrega'));
+    });
+    @endif
 
     // Spinner al enviar formularios
     document.querySelectorAll('form').forEach(form => {

--- a/resources/views/admin/pedidos/index.blade.php
+++ b/resources/views/admin/pedidos/index.blade.php
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Panel de Gestión de Pedidos | Supermercado Atlantia</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-o9N1j7kGStbFh8g1FVLzeuL1Yypw5v1sC0qf2m0wEgg=" crossorigin=""/>
     <style>
         :root{--vino:#800020;--vino-hover:#a1002c;--gris-claro:#f4f4f4;--borde:#e0e0e0;--texto:#333;--pendiente:#FF9800;--preparando:#9C27B0;--listo:#FFC107;--entregado:#4CAF50}
         *{margin:0;padding:0;box-sizing:border-box;font-family:'Segoe UI',Tahoma,Geneva,Verdana,sans-serif}
@@ -55,6 +56,7 @@
         .btn-cancel{background:#6c757d;color:#fff}.btn-confirm{background:var(--vino);color:#fff}
         .detalles-pedido{margin-bottom:1.5rem}.detalle-item{display:flex;justify-content:space-between;margin-bottom:.5rem;padding-bottom:.5rem;border-bottom:1px solid #eee}
         .detalle-label{font-weight:700;color:#555}.lista-productos{margin-top:1rem}.producto-detalle{display:flex;justify-content:space-between;padding:.5rem 0;border-bottom:1px solid #f0f0f0}
+        #mapa-detalle{width:100%;height:220px;border-radius:10px;margin-top:1rem;border:1px solid #e0e0e0}
         @media (max-width:768px){.estados{grid-template-columns:1fr}.filtros{overflow-x:auto;padding-bottom:1rem}.stats-container{flex-direction:column;align-items:center}.stat-card{width:100%;max-width:300px}header{flex-direction:column;text-align:center}.header-left{flex-direction:column}.btn-back{align-self:flex-start}.modal-content{width:95%;margin:1rem}}
         @media (max-width:480px){body{padding:.5rem}header{padding:1rem}h1{font-size:1.5rem}.pedido-acciones{flex-direction:column}.btn{width:100%;justify-content:center}.modal-footer{flex-direction:column}}
     </style>
@@ -64,6 +66,55 @@
 @php
     // Plantilla segura de URL para el form del modal (evita hardcodear)
     $asignarUrlTemplate = route('admin.pedidos.asignar-repartidor', ['pedido' => '__ID__']);
+
+    $pedidosDataset = ($pedidos ?? collect())->map(function ($pedido) {
+        $dir = $pedido->direccion_envio ?? [];
+        $lat = data_get($dir, 'lat');
+        $lng = data_get($dir, 'lng');
+        $gmaps = ($lat && $lng) ? sprintf('https://www.google.com/maps?q=%s,%s', $lat, $lng) : null;
+        $items = ($pedido->itemsSupermercado ?? collect())->map(function ($item) {
+            $precio = (float) $item->precio_unitario;
+            $cantidad = (int) $item->cantidad;
+            return [
+                'nombre'    => optional($item->producto)->nombre ?? 'Producto',
+                'cantidad'  => $cantidad,
+                'precio'    => $precio,
+                'subtotal'  => round($precio * $cantidad, 2),
+            ];
+        })->values();
+
+        return [
+            'id'           => $pedido->id,
+            'codigo'       => $pedido->codigo ?? ('PED-' . $pedido->id),
+            'total'        => (float) $pedido->total,
+            'estado'       => $pedido->estado_global,
+            'metodo_pago'  => $pedido->metodo_pago,
+            'created_at'   => optional($pedido->created_at)->format('d/m/Y H:i'),
+            'cliente'      => [
+                'nombre'  => optional($pedido->cliente)->name,
+                'email'   => optional($pedido->cliente)->email,
+                'telefono'=> optional($pedido->cliente)->telefono,
+            ],
+            'repartidor'   => [
+                'nombre'  => optional($pedido->repartidor)->name,
+                'telefono'=> optional($pedido->repartidor)->telefono,
+            ],
+            'direccion'    => [
+                'texto'   => $pedido->direccion_formateada,
+                'lat'     => $lat,
+                'lng'     => $lng,
+                'google'  => $gmaps,
+                'referencia' => data_get($dir, 'referencia'),
+            ],
+            'facturacion'  => [
+                'requiere'  => (bool) data_get($pedido->facturacion, 'requiere', false),
+                'nit'       => data_get($pedido->facturacion, 'nit', 'CF'),
+                'nombre'    => data_get($pedido->facturacion, 'nombre'),
+                'direccion' => data_get($pedido->facturacion, 'direccion'),
+            ],
+            'items'        => $items,
+        ];
+    })->values();
 @endphp
 
 <div class="container">
@@ -99,7 +150,7 @@
                 <span class="contador">{{ $pendientesCount ?? 0 }}</span>
             </div>
             <div class="pedidos-list">
-                @forelse(($pedidos ?? collect())->where('estado','pendiente') as $pedido)
+                @forelse(($pedidos ?? collect())->where('estado_global','pendiente') as $pedido)
                     <div class="pedido">
                         <div class="pedido-id">
                             <span>ID: {{ $pedido->id }}</span>
@@ -109,16 +160,19 @@
                         <div class="pedido-total">Q{{ number_format($pedido->total, 2) }}</div>
                         <div class="pedido-fecha">{{ $pedido->created_at->format('d/m/Y H:i') }}</div>
 
-                        @if(($pedido->productos ?? collect())->count())
+                        @php($itemsSuper = $pedido->itemsSupermercado ?? collect())
+                        @if($itemsSuper->count())
                             <div class="pedido-productos">
-                                @foreach($pedido->productos as $producto)
+                                @foreach($itemsSuper as $item)
                                     <div class="producto-item">
-                                        <span>{{ $producto->nombre }} x{{ $producto->pivot->cantidad ?? 1 }}</span>
-                                        <span>Q{{ number_format(($producto->pivot->precio ?? $producto->precio) * ($producto->pivot->cantidad ?? 1), 2) }}</span>
+                                        <span>{{ optional($item->producto)->nombre }} x{{ $item->cantidad }}</span>
+                                        <span>Q{{ number_format(($item->precio_unitario ?? 0) * ($item->cantidad ?? 1), 2) }}</span>
                                     </div>
                                 @endforeach
                             </div>
                         @endif
+                        <div class="pedido-info"><i class="fas fa-map-marker-alt"></i> {{ $pedido->direccion_formateada ?? 'Dirección no especificada' }}</div>
+                        <div class="pedido-info"><i class="fas fa-money-check-alt"></i> {{ ucfirst(str_replace('_',' ', $pedido->metodo_pago ?? 'efectivo')) }}</div>
 
                         <div class="pedido-acciones">
                             <button class="btn btn-asignar" onclick="abrirModalAsignar({{ $pedido->id }})">
@@ -142,12 +196,14 @@
                 <span class="contador">{{ $preparandoCount ?? 0 }}</span>
             </div>
             <div class="pedidos-list">
-                @forelse(($pedidos ?? collect())->where('estado','preparando') as $pedido)
+                @forelse(($pedidos ?? collect())->where('estado_global','preparando') as $pedido)
                     <div class="pedido pedido-preparando">
                         <div class="pedido-id"><span>ID: {{ $pedido->id }}</span></div>
                         <div class="pedido-cliente">{{ $pedido->cliente->name ?? 'Cliente no disponible' }}</div>
                         <div class="pedido-total">Q{{ number_format($pedido->total, 2) }}</div>
                         <div class="pedido-fecha">{{ $pedido->created_at->format('d/m/Y H:i') }}</div>
+                        <div class="pedido-info"><i class="fas fa-map-marker-alt"></i> {{ $pedido->direccion_formateada ?? 'Dirección no especificada' }}</div>
+                        <div class="pedido-info"><i class="fas fa-money-check-alt"></i> {{ ucfirst(str_replace('_',' ', $pedido->metodo_pago ?? 'efectivo')) }}</div>
 
                         <div class="pedido-acciones">
                             <form action="{{ route('admin.pedidos.actualizar-estado', $pedido->id) }}" method="POST" style="display:inline">
@@ -172,12 +228,14 @@
                 <span class="contador">{{ $listosCount ?? 0 }}</span>
             </div>
             <div class="pedidos-list">
-                @forelse(($pedidos ?? collect())->where('estado','listo') as $pedido)
+                @forelse(($pedidos ?? collect())->where('estado_global','listo') as $pedido)
                     <div class="pedido pedido-listo">
                         <div class="pedido-id"><span>ID: {{ $pedido->id }}</span></div>
                         <div class="pedido-cliente">{{ $pedido->cliente->name ?? 'Cliente no disponible' }}</div>
                         <div class="pedido-total">Q{{ number_format($pedido->total, 2) }}</div>
                         <div class="pedido-fecha">{{ $pedido->created_at->format('d/m/Y H:i') }}</div>
+                        <div class="pedido-info"><i class="fas fa-map-marker-alt"></i> {{ $pedido->direccion_formateada ?? 'Dirección no especificada' }}</div>
+                        <div class="pedido-info"><i class="fas fa-money-check-alt"></i> {{ ucfirst(str_replace('_',' ', $pedido->metodo_pago ?? 'efectivo')) }}</div>
 
                         <div class="pedido-acciones">
                             <form action="{{ route('admin.pedidos.actualizar-estado', $pedido->id) }}" method="POST" style="display:inline">
@@ -202,12 +260,14 @@
                 <span class="contador">{{ $entregadosCount ?? 0 }}</span>
             </div>
             <div class="pedidos-list">
-                @forelse(($pedidos ?? collect())->where('estado','entregado') as $pedido)
+                @forelse(($pedidos ?? collect())->where('estado_global','entregado') as $pedido)
                     <div class="pedido pedido-entregado">
                         <div class="pedido-id"><span>ID: {{ $pedido->id }}</span></div>
                         <div class="pedido-cliente">{{ $pedido->cliente->name ?? 'Cliente no disponible' }}</div>
                         <div class="pedido-total">Q{{ number_format($pedido->total, 2) }}</div>
                         <div class="pedido-fecha">{{ $pedido->created_at->format('d/m/Y H:i') }}</div>
+                        <div class="pedido-info"><i class="fas fa-map-marker-alt"></i> {{ $pedido->direccion_formateada ?? 'Dirección no especificada' }}</div>
+                        <div class="pedido-info"><i class="fas fa-money-check-alt"></i> {{ ucfirst(str_replace('_',' ', $pedido->metodo_pago ?? 'efectivo')) }}</div>
                         <div class="pedido-info"><i class="fas fa-user"></i> Entregado por: {{ $pedido->repartidor->name ?? 'Sistema' }}</div>
                         <div class="pedido-acciones">
                             <button class="btn btn-detalles" onclick="abrirModalDetalles({{ $pedido->id }})"><i class="fas fa-eye"></i> Ver Detalles</button>
@@ -269,9 +329,12 @@
     </div>
 </div>
 
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o9N1j7kGStbFh8g1FVLzeuL1Yypw5v1sC0qf2m0wEgg=" crossorigin=""></script>
 <script>
     // Plantilla de ruta generada por Laravel (más robusto que hardcodear)
     const ASIGNAR_URL_TEMPLATE = @json($asignarUrlTemplate);
+    const PEDIDOS_DATA = @json($pedidosDataset);
+    let detalleMap = null;
 
     function abrirModalAsignar(pedidoId) {
         document.getElementById('pedidoId').value = pedidoId;
@@ -281,28 +344,85 @@
     }
 
     function abrirModalDetalles(pedidoId) {
-        document.getElementById('detallesContenido').innerHTML = '<p>Cargando detalles del pedido...</p>';
-        document.getElementById('modalDetalles').style.display = 'flex';
-        setTimeout(() => {
-            document.getElementById('detallesContenido').innerHTML = `
-                <div class="detalles-pedido">
-                    <div class="detalle-item"><span class="detalle-label">ID del Pedido:</span><span>${pedidoId}</span></div>
-                    <div class="detalle-item"><span class="detalle-label">Cliente:</span><span>Cliente #${pedidoId}</span></div>
-                    <div class="detalle-item"><span class="detalle-label">Total:</span><span>Q${(pedidoId * 10).toFixed(2)}</span></div>
-                    <div class="detalle-item"><span class="detalle-label">Estado:</span><span>Pendiente</span></div>
-                    <div class="detalle-item"><span class="detalle-label">Fecha:</span><span>${new Date().toLocaleDateString()}</span></div>
+        const pedido = PEDIDOS_DATA.find(p => p.id === pedidoId);
+        if (!pedido) {
+            document.getElementById('detallesContenido').innerHTML = '<p>No se encontró la información del pedido.</p>';
+            document.getElementById('modalDetalles').style.display = 'flex';
+            return;
+        }
+
+        const productosHtml = pedido.items.length
+            ? pedido.items.map(it => `
+                <div class="producto-detalle">
+                    <span>${it.nombre} x${it.cantidad}</span>
+                    <span>Q${it.subtotal.toFixed(2)}</span>
                 </div>
-                <div class="lista-productos">
-                    <h3>Productos</h3>
-                    <div class="producto-detalle"><span>Producto 1 x2</span><span>Q20.00</span></div>
-                    <div class="producto-detalle"><span>Producto 2 x1</span><span>Q15.50</span></div>
-                </div>`;
-        }, 400);
+            `).join('')
+            : '<div class="producto-detalle"><span>Sin productos del supermercado.</span><span></span></div>';
+
+        const facturacionHtml = pedido.facturacion.requiere
+            ? `<div class="detalle-item"><span class="detalle-label">Factura:</span><span>NIT ${pedido.facturacion.nit} · ${pedido.facturacion.nombre ?? '—'}</span></div>`
+            : '<div class="detalle-item"><span class="detalle-label">Factura:</span><span>No requerida</span></div>';
+
+        const direccionHtml = `
+            <div class="detalle-item"><span class="detalle-label">Dirección:</span><span>${pedido.direccion.texto ?? '—'}</span></div>
+            ${pedido.direccion.referencia ? `<div class="detalle-item"><span class="detalle-label">Referencia:</span><span>${pedido.direccion.referencia}</span></div>` : ''}
+            ${pedido.direccion.google ? `<div class="detalle-item"><span class="detalle-label">Mapa:</span><span><a href="${pedido.direccion.google}" target="_blank">Abrir en Google Maps</a></span></div>` : ''}
+        `;
+
+        const repartidorHtml = pedido.repartidor.nombre
+            ? `<div class="detalle-item"><span class="detalle-label">Repartidor:</span><span>${pedido.repartidor.nombre} (${pedido.repartidor.telefono ?? 'sin teléfono'})</span></div>`
+            : '';
+
+        const contenido = `
+            <div class="detalles-pedido">
+                <div class="detalle-item"><span class="detalle-label">Pedido:</span><span>#${pedido.codigo}</span></div>
+                <div class="detalle-item"><span class="detalle-label">Cliente:</span><span>${pedido.cliente.nombre ?? '—'} (${pedido.cliente.telefono ?? 'sin teléfono'})</span></div>
+                <div class="detalle-item"><span class="detalle-label">Correo:</span><span>${pedido.cliente.email ?? '—'}</span></div>
+                <div class="detalle-item"><span class="detalle-label">Total:</span><span>Q${pedido.total.toFixed(2)}</span></div>
+                <div class="detalle-item"><span class="detalle-label">Estado:</span><span>${pedido.estado}</span></div>
+                <div class="detalle-item"><span class="detalle-label">Método de pago:</span><span>${(pedido.metodo_pago || 'efectivo').replace(/_/g,' ')}</span></div>
+                <div class="detalle-item"><span class="detalle-label">Fecha:</span><span>${pedido.created_at ?? '—'}</span></div>
+                ${facturacionHtml}
+                ${direccionHtml}
+                ${repartidorHtml}
+            </div>
+            <div class="lista-productos">
+                <h3>Productos del supermercado</h3>
+                ${productosHtml}
+            </div>
+            ${pedido.direccion.lat && pedido.direccion.lng ? '<div id="mapa-detalle"></div>' : ''}
+        `;
+
+        const contenedor = document.getElementById('detallesContenido');
+        contenedor.innerHTML = contenido;
+        document.getElementById('modalDetalles').style.display = 'flex';
+
+        if (pedido.direccion.lat && pedido.direccion.lng) {
+            setTimeout(() => {
+                if (detalleMap) {
+                    detalleMap.remove();
+                }
+                detalleMap = L.map('mapa-detalle').setView([pedido.direccion.lat, pedido.direccion.lng], 16);
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    maxZoom: 19,
+                    attribution: '&copy; OpenStreetMap'
+                }).addTo(detalleMap);
+                L.marker([pedido.direccion.lat, pedido.direccion.lng]).addTo(detalleMap)
+                    .bindPopup(pedido.direccion.texto || 'Ubicación de entrega');
+            }, 50);
+        }
     }
 
-    function cerrarModal(id){ document.getElementById(id).style.display='none'; }
+    function cerrarModal(id){
+        document.getElementById(id).style.display='none';
+        if (id === 'modalDetalles' && detalleMap) {
+            detalleMap.remove();
+            detalleMap = null;
+        }
+    }
 
-    window.onclick = function(e){ if(e.target.classList.contains('modal')) e.target.style.display='none'; }
+    window.onclick = function(e){ if(e.target.classList.contains('modal')) cerrarModal(e.target.id); }
 
     document.addEventListener('DOMContentLoaded', () => {
         const filtros = document.querySelectorAll('.filtro-btn');


### PR DESCRIPTION
## Summary
- add a Payment model and facturacion JSON column to pedidos to persist billing metadata
- persist checkout billing fields separately from the shipping address and expose vendor coordinates and payment method
- fix admin/vendor order views and controllers to show only relevant items, display address maps, and respect estado_global counts

## Testing
- php -l app/Http/Controllers/Admin/PedidoController.php
- php -l app/Http/Controllers/CarritoController.php
- php -l app/Http/Controllers/Vendedor/PedidoController.php
- php -l app/Models/Payment.php

------
https://chatgpt.com/codex/tasks/task_e_68e3f614ab088333b552c0450f9bc0c3